### PR TITLE
Add workflow: Release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,5 +45,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body: |
+            Changes in this release
+          draft: false
+          prerelease: false
+  deploy:
+    name: Publish to PyPI
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: Deploy package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,18 @@
 from setuptools import setup, find_packages
 
+
 def read_desc():
     with open('README.md', 'r') as desc:
         return desc.read()
 
-setup (
+
+setup(
     name="Konsave",
-    version="1.0.5",
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
     author="Prayag Jain",
     author_email="prayagjain2@gmail.com",
-    description = "A program that lets you save your Plasma configuration in an instant!",
+    description="A program that lets you save your Plasma configuration in an instant!",
     long_description=read_desc(),
     long_description_content_type="text/markdown",
     url="https://www.github.com/prayag2/konsave/",
@@ -17,7 +20,7 @@ setup (
     package_data={'config': ['conf.yaml']},
     include_package_data=True,
     install_requires=['PyYaml'],
-    classifiers = [
+    classifiers=[
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: POSIX",
         "Environment :: Console",


### PR DESCRIPTION
Closes #5.

Changes:

- Add GitHub Actions workflow "Release". Runs on tag push, named `v*` (e.g. `v1.0.5`). This workflow creates a GitHub release and publishes the package to PyPI repository.
- Change setup.py manual versioning to SCM versioning - the tag's version determines the package's version. This means that tag `v1.0.5` results in package version `1.0.5` on PyPI. This also means that the package version won't be maintained via source code, but via Git tags.
- Requires package maintainer to create PyPI API token and add it to the project's "secrets" as `PYPI_API_TOKEN`. See [encrypted secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) page for details on how to do it.
