### PR TITLE
Added khotkeysrc to backup Custom shortcuts

### DIFF
--- a/konsave/conf.yaml
+++ b/konsave/conf.yaml
@@ -26,3 +26,5 @@ entries:
     - oxygenrc
     - lightlyrc 
     - ksplashrc
+    - khotkeysrc
+    


### PR DESCRIPTION
Note: In the test I did, Custom Shortcuts that are the same as Global Shortcuts or Standard Shortcuts are overwritten.

If this PR is mixed, a note in the README can be useful.