### PR TITLE
Changed some things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-09-07
+### Added
+- The following placeholders for `config.yaml` were added:
+    1. `$SHARE_DIR`: It points to `$HOME/.local/share`
+    2. `$BIN_DIR`: It points to `$HOME/.local/bin`
+
+### Changed
+- Now, there's no need to check for the ID of a profile if you already know its name. You can remove, apply and export a profile using its name. For example `konsave --export myprofile`. See [#38](https://github.com/Prayag2/konsave/issues/38)
+- Replaced the words "variables and functions" with "placeholders".
+- Updated readme.
+
+### Removed
+- You'll no longer be able to use IDs to remove, apply and export profiles. You have to use the name of the profile to do so.
+- The following placeholders were removed:
+    - `$KONSAVE_DIR`
+    - `$CONFIG_DIR`
+
 ## [2.0.2] - 2021-04-13
 ### Fixed
 - Fixed a bug with export. Previously, exporting a profile would export the current profile but now it will export the specified profile.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Install from PyPI
 ### List all profiles
 `konsave -l` or `konsave --list`
 ### Remove a profile
-`konsave -r <profile id>` or `konsave --remove <profile id>`
+`konsave -r <profile name>` or `konsave --remove <profile name>`
 ### Apply a profile
-`konsave -a <profile id>` or `konsave --apply <profile id>`
+`konsave -a <profile name>` or `konsave --apply <profile name>`
 You may need to log out and log in to see all the changes.  
 ### Export a profile as a ".knsv" file to share it with your friends!
-`konsave -e <profile id>` or `konsave --export-profile <profile id>`
+`konsave -e <profile name>` or `konsave --export-profile <profile name>`
 ### Import a ".knsv" file
 `konsave -i <path to the file>` or `konsave --import-profile <path to the file>`
 ### Show current version
@@ -89,16 +89,17 @@ export:
                 - folder2
 ```
 
-### Using variables and functions
-You can use a few variables and functions in the `location` of each entry in the configuration file. These are:  
-`$HOME`: points to the home directory  
-`$CONFIG_DIR`: points to `~/.config`  
-`$KONSAVE_DIR`: points to `~/.config/konsave`  
-`$PROFILES_DIR`: points to `~/.config/konsave/profiles`  
-`${ENDS_WITH="text"}`: for folders with different names on different computers whose names end with the same thing.  
-The best example for this is the ".default-release" folder in `~/.mozilla/firefox`.  
-`${BEGINS_WITH="text"}`: for folders with different names on different computers whose names start with the same thing.  
-Here's an example of how you can use these variables:
+### Using placeholders
+You can use a few placeholders in the `location` of each entry in the configuration file. These are:  
+`$HOME`: the home directory
+`$CONFIG_DIR`: refers to "$HOME/.config/"
+`$SHARE_DIR`: refers to "$HOME/.local/share"
+`$BIN_DIR`: refers to "$HOME/.local/bin"
+`${ENDS_WITH="text"}`: for folders with different names on different computers whose names end with the same thing.
+The best example for this is the ".default-release" folder of firefox.
+`${BEGINS_WITH="text"}`: for folders with different names on different computers whose names start with the same thing.
+
+
 ```
 save:
     firefox:

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -52,25 +52,25 @@ def _get_parser() -> argparse.ArgumentParser:
         "-r",
         "--remove",
         required=False,
-        type=int,
+        type=str,
         help="Remove the specified profile",
-        metavar="<id>",
+        metavar="<name>",
     )
     parser.add_argument(
         "-a",
         "--apply",
         required=False,
-        type=int,
+        type=str,
         help="Apply the specified profile",
-        metavar="<id>",
+        metavar="<name>",
     )
     parser.add_argument(
         "-e",
         "--export-profile",
         required=False,
-        type=int,
+        type=str,
         help="Export a profile and share with your friends!",
-        metavar="<id>",
+        metavar="<name>",
     )
     parser.add_argument(
         "-i",

--- a/konsave/conf_kde.yaml
+++ b/konsave/conf_kde.yaml
@@ -1,14 +1,16 @@
 ---
-# This is the configuration file for konsave. This file is pre-configured for KDE Plasma users.
+# This is the configuration file for konsave.
+# This file is pre-configured for KDE Plasma users.
 # This will backup all the important files for your Plasma customizations.
-# Please make sure it follows the correct format for proper working of konsave.
+# Please make sure it follows the correct format for proper working of Konsave.
 # The format should be:
 # ---
 # save:
 #     name:
 #         location: "path/to/parent/directory"
 #         entries: 
-#         # these are files to be backed up. They should be present in the specified location.
+#         # these are files which will be backed up. 
+#         # They should be present in the specified location.
 #             - file1
 #             - file2
 # export:
@@ -21,18 +23,18 @@
 #             - file1
 #             - file2
 # ...
-# You can use these variables and functions in the locations of different entries:
+# You can use these placeholders in the "location" of each item:
 # $HOME: the home directory
-# $PROFILES_DIR: directory where all profiles are saved
 # $CONFIG_DIR: refers to "$HOME/.config/"
-# $KONSAVE_DIR: the location where all Konsave files are stored ("$CONFIG_DIR/konsave").
+# $SHARE_DIR: refers to "$HOME/.local/share"
+# $BIN_DIR: refers to "$HOME/.local/bin"
 # ${ENDS_WITH="text"}: for folders with different names on different computers whose names end with the same thing.
-# The best example for this is the ".default-release" folder for firefox.
+# The best example for this is the "*.default-release" folder of firefox.
 # ${BEGINS_WITH="text"}: for folders with different names on different computers whose names start with the same thing.
 
 save:
     configs:
-        location: "$HOME/.config"
+        location: "$CONFIG_DIR"
         entries:
             - gtk-2.0
             - gtk-3.0
@@ -62,14 +64,21 @@ save:
             - ksplashrc
             - khotkeysrc
 
-    # Here are a few examples of how you can add more stuff to back up
+    app_layouts:
+        location: "$HOME/.local/share/kxmlgui5"
+        entries:
+            - dolphin
+            - konsole
+
+    # Here are a few examples of how you can add more stuff to back up.
+    # Uncomment these lines if you want.
     # firefox:
     #     location: "$HOME/.mozilla/firefox/${ENDS_WITH='.default-release'}"
     #     entries:
     #         - chrome # for firefox customizations
 
-    # oss:
-    #     location: "$HOME/.config/Code - OSS/User/"
+    # code oss:
+    #     location: "$CONFIG_DIR/Code - OSS/User/"
     #     entries:
     #         - settings.json
 
@@ -77,26 +86,28 @@ save:
 # The following files will only be used for exporting and importing.
 export:
     share_folder:
-        location: "$HOME/.local/share"
+        location: "$SHARE_DIR"
         entries:
             - plasma
             - kwin
             - konsole
             - fonts
             - color-schemes
-            # Add icons only if necessary. They can take up to a few gigabytes of storage easily.
-            #- icons
+            - aurorae
+            - icons
+            - wallpapers
+
     home_folder:
         location: "$HOME/"
         entries:
             - .fonts
             - .themes
-            - .icons # this refers to the cursor pack and not the icon pack.
+            - .icons
     
         
     # You can add more files to export like this
     # name:
-    #     location: "path"
+    #     location: "path/to/parent/directory"
     #     entries:
     #         - file1
     #         - file2

--- a/konsave/consts.py
+++ b/konsave/consts.py
@@ -7,6 +7,8 @@ from konsave import __version__
 
 HOME = os.path.expandvars("$HOME")
 CONFIG_DIR = os.path.join(HOME, ".config")
+SHARE_DIR = os.path.join(HOME, ".local/share")
+BIN_DIR = os.path.join(HOME, ".local/bin")
 KONSAVE_DIR = os.path.join(CONFIG_DIR, "konsave")
 PROFILES_DIR = os.path.join(KONSAVE_DIR, "profiles")
 CONFIG_FILE = os.path.join(KONSAVE_DIR, "conf.yaml")

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -174,7 +174,7 @@ def save_profile(name, profile_list, force=False):
         folder = os.path.join(profile_dir, section)
         mkdir(folder)
         for entry in konsave_config[section]["entries"]:
-            source = os.path.join(location, entry)
+            source = os.path.join(location, entry) 
             dest = os.path.join(folder, entry)
             if os.path.exists(source):
                 if os.path.isdir(source):
@@ -188,25 +188,21 @@ def save_profile(name, profile_list, force=False):
 
 
 @exception_handler
-def apply_profile(profile_id, profile_list, profile_count):
+def apply_profile(profile_name, profile_list, profile_count):
     """Applies profile of the given id.
 
     Args:
-        profile_id: id of the profile to be applied
+        profile_name: name of the profile to be applied
         profile_list: the list of all created profiles
         profile_count: number of profiles created
     """
 
-    # Lowering id by 1
-    profile_id -= 1
-
     # assert
     assert profile_count != 0, "No profile saved yet."
-    assert profile_id in range(profile_count), "Profile not found :("
+    assert profile_name in profile_list, "Profile not found :("
 
     # run
-    name = profile_list[profile_id]
-    profile_dir = os.path.join(PROFILES_DIR, name)
+    profile_dir = os.path.join(PROFILES_DIR, profile_name)
 
     log("copying files...")
 
@@ -216,55 +212,48 @@ def apply_profile(profile_id, profile_list, profile_count):
         location = os.path.join(profile_dir, name)
         copy(location, profile_config[name]["location"])
 
-
     log(
         "Profile applied successfully! Please log-out and log-in to see the changes completely!"
     )
 
 
 @exception_handler
-def remove_profile(profile_id, profile_list, profile_count):
+def remove_profile(profile_name, profile_list, profile_count):
     """Removes the specified profile.
 
     Args:
-        profile_id: id of the profile to be removed
+        profile_name: name of the profile to be removed
         profile_list: the list of all created profiles
         profile_count: number of profiles created
     """
 
-    # Lowering profile_id by 1
-    profile_id -= 1
-
     # assert
-    assert profile_id in range(profile_count), "Profile not found."
+    assert profile_count != 0, "No profile saved yet."
+    assert profile_name in profile_list, "Profile not found."
 
     # run
-    item = profile_list[profile_id]
     log("removing profile...")
-    shutil.rmtree(os.path.join(PROFILES_DIR, item))
+    shutil.rmtree(os.path.join(PROFILES_DIR, profile_name))
     log("removed profile successfully")
 
 
 @exception_handler
-def export(profile_id, profile_list, profile_count):
+def export(profile_name, profile_list, profile_count):
     """It will export the specified profile as a ".knsv" file in the home directory.
 
     Args:
-        profile_id: id of the profile to be exported
+        profile_name: name of the profile to be exported
         profile_list: the list of all created profiles
         profile_count: number of profiles created
     """
 
-    # lowering profile_id by 1
-    profile_id -= 1
-
     # assert
-    assert profile_id in range(profile_count), "Profile not found."
+    assert profile_count != 0, "No profile saved yet."
+    assert profile_name in profile_list, "Profile not found."
 
     # run
-    item = profile_list[profile_id]
-    profile_dir = os.path.join(PROFILES_DIR, item)
-    export_path = os.path.join(HOME, item)
+    profile_dir = os.path.join(PROFILES_DIR, profile_name)
+    export_path = os.path.join(HOME, profile_name)
 
     if os.path.exists(export_path):
         rand_str = list("abcdefg12345")

--- a/konsave/parse.py
+++ b/konsave/parse.py
@@ -3,7 +3,7 @@ This module parses conf.yaml
 """
 import os
 import re
-from konsave.consts import HOME, CONFIG_DIR, KONSAVE_DIR, PROFILES_DIR
+from konsave.consts import HOME, CONFIG_DIR, SHARE_DIR, BIN_DIR
 
 
 def ends_with(grouped_regex, path) -> str:
@@ -89,9 +89,9 @@ tokens = {
         "dict": {
             "HOME": HOME,
             "CONFIG_DIR": CONFIG_DIR,
-            "KONSAVE_DIR": KONSAVE_DIR,
-            "PROFILES_DIR": PROFILES_DIR,
-        }
+            "SHARE_DIR": SHARE_DIR,
+            "BIN_DIR": BIN_DIR
+            }
     },
     "functions": {
         "raw_regex": r"\{\w+\=(?:\"|')\S+(?:\"|')\}",


### PR DESCRIPTION
### Added
- The following placeholders for `config.yaml` were added:
    1. `$SHARE_DIR`: It points to `$HOME/.local/share`
    2. `$BIN_DIR`: It points to `$HOME/.local/bin`

### Changed
- Now, there's no need to check for the ID of a profile if you already know its name. You can remove, apply and export a profile using its name. For example `konsave --export myprofile`. See [#38](https://github.com/Prayag2/konsave/issues/38)
- Replaced the words "variables and functions" with "placeholders".
- Updated readme.

### Removed
- You'll no longer be able to use IDs to remove, apply and export profiles. You have to use the name of the profile to do so.
- The following placeholders were removed:
    - `$KONSAVE_DIR`
    - `$CONFIG_DIR`