### PR TITLE
parse empy entries as empty lists so prevent exception in loops

### DIFF
--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -127,7 +127,20 @@ def read_konsave_config(config_file) -> dict:
     parse_keywords(tokens, TOKEN_SYMBOL, konsave_config)
     parse_functions(tokens, TOKEN_SYMBOL, konsave_config)
 
-    return konsave_config
+    # in some cases conf.yaml may contain nothing in "entries"
+    # yaml parses these as NoneType which are not iterable which throws an exception
+    # we can convert all None-Entries into empty lists recursively so they are simply skipped in loops later on
+    def convert_none_to_empty_list(data):
+        if isinstance(data, list):
+            data[:] = [convert_none_to_empty_list(i) for i in data]
+        elif isinstance(data, dict):
+            for k, v in data.items():
+                data[k] = convert_none_to_empty_list(v)
+        return [] if data is None else data
+
+
+    return convert_none_to_empty_list(konsave_config)
+
 
 
 @exception_handler


### PR DESCRIPTION
in some cases conf.yaml may contain nothing under "entries"
yaml parses these as NoneType which are not iterable. This triggers an exception in loops

For example:

_func.py_


```
def save_profile(name, profile_list, force=False):
  ...
  for section in konsave_config:
          location = konsave_config[section]["location"]
          folder = os.path.join(profile_dir, section)
          mkdir(folder)
          for entry in konsave_config[section]["entries"]:    #Throws and error
              source = os.path.join(location, entry) 
              dest = os.path.join(folder, entry)
              if os.path.exists(source):
                  if os.path.isdir(source):
                      copy(source, dest)
                  else:
                      shutil.copy(source, dest)
```

To resolve this we can convert all None-Entries into empty lists recursively before returning the parsed config


This should also resolve #47 