### PR TITLE
Iss66 - Improvements to export handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Install from PyPI
 You may need to log out and log in to see all the changes.  
 ### Export a profile as a ".knsv" file to share it with your friends!
 `konsave -e <profile name>` or `konsave --export-profile <profile name>`
+### Export a profile, setting the output dir and archive name
+`konsave -e <profile name> -d <archive directory> -n <archive name>`
+or
+`konsave --export-profile <profile name> --archive-directory <archive directory> --export-name <export name>`
+### Export a profile, overwrite files if they already exist
+`konsave -e <profile name> -f` or `konsave --export-profile <profile name> --force`
+*note: without --force, the export will be appended with the date and time to ensure unique naming and no data is overwritten
 ### Import a ".knsv" file
 `konsave -i <path to the file>` or `konsave --import-profile <path to the file>`
 ### Show current version

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -87,6 +87,14 @@ def _get_parser() -> argparse.ArgumentParser:
         help="Overwrite already saved profiles",
     )
     parser.add_argument(
+    parser.add_argument(
+        "-n",
+        "--export-name",
+        required=False,
+        help="Specify the export name when exporting a profile",
+        metavar="<archive-name>"
+    )
+    parser.add_argument(
         "-v", "--version", required=False, action="store_true", help="Show version"
     )
     parser.add_argument(

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -87,6 +87,12 @@ def _get_parser() -> argparse.ArgumentParser:
         help="Overwrite already saved profiles",
     )
     parser.add_argument(
+        "-d",
+        "--export-directory",
+        required=False,
+        help="Specify the export directory when exporting a profile",
+        metavar="<directory>"
+    )
     parser.add_argument(
         "-n",
         "--export-name",

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -127,7 +127,8 @@ def main():
     elif args.apply:
         apply_profile(args.apply, list_of_profiles, length_of_lop)
     elif args.export_profile:
-        export(args.export_profile, list_of_profiles, length_of_lop)
+        export(args.export_profile, list_of_profiles, length_of_lop,
+               args.export_directory, args.export_name, args.force)
     elif args.import_profile:
         import_profile(args.import_profile)
     elif args.version:

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -79,7 +79,7 @@ def log(msg, *args, **kwargs):
         *args: any arguments for the function print()
         **kwargs: any keyword arguments for the function print()
     """
-    print(f"Konsave: {msg.capitalize()}", *args, **kwargs)
+    print(f"Konsave: {msg}", *args, **kwargs)
 
 
 @exception_handler

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -268,7 +268,6 @@ def export(profile_name, profile_list, profile_count, archive_dir, archive_name,
 
     # run
     profile_dir = os.path.join(PROFILES_DIR, profile_name)
-    export_path = os.path.join(HOME, profile_name)
 
     if archive_name:
         profile_name = archive_name

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -249,13 +249,17 @@ def remove_profile(profile_name, profile_list, profile_count):
 
 
 @exception_handler
-def export(profile_name, profile_list, profile_count):
-    """It will export the specified profile as a ".knsv" file in the home directory.
+def export(profile_name, profile_list, profile_count, archive_dir, archive_name, force):
+    """It will export the specified profile as a ".knsv" to the specified directory.
+       If there is no specified directory, the directory is set to the current working directory.
 
     Args:
         profile_name: name of the profile to be exported
         profile_list: the list of all created profiles
         profile_count: number of profiles created
+        directory: output directory for the export
+        force: force the overwrite of existing export file
+        name: the name of the resulting archive
     """
 
     # assert

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -40,7 +40,7 @@ def exception_handler(func):
             function = func(*args, **kwargs)
         except Exception as err:
             dateandtime = datetime.now().strftime("[%d/%m/%Y %H:%M:%S]")
-            log_file = os.path.join(HOME, ".konsave_log.txt")
+            log_file = os.path.join(HOME, ".cache/konsave_log.txt")
 
             with open(log_file, "a") as file:
                 file.write(dateandtime + "\n")

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -273,6 +273,22 @@ def export(profile_name, profile_list, profile_count, archive_dir, archive_name,
     if archive_name:
         profile_name = archive_name
 
+    if archive_dir:
+        export_path = os.path.join(archive_dir, profile_name)
+    else:
+        export_path = os.path.join(os.getcwd(), profile_name)
+
+    # Only continue if export_path, export_path.ksnv and export_path.zip don't exist
+    # Appends date and time to create a unique file name
+    if not force:
+        while True:
+            paths = [f"{export_path}", f"{export_path}.knsv", f"{export_path}.zip"]
+            if any([os.path.exists(path) for path in paths]):
+                time = "f{:%d-%m-%Y:%H-%M-%S}".format(datetime.now())
+                export_path = f"{export_path}_{time}"
+            else:
+                break
+
     # compressing the files as zip
     log("Exporting profile. It might take a minute or two...")
 

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -270,10 +270,8 @@ def export(profile_name, profile_list, profile_count, archive_dir, archive_name,
     profile_dir = os.path.join(PROFILES_DIR, profile_name)
     export_path = os.path.join(HOME, profile_name)
 
-    if os.path.exists(export_path):
-        rand_str = list("abcdefg12345")
-        shuffle(rand_str)
-        export_path = export_path + "".join(rand_str)
+    if archive_name:
+        profile_name = archive_name
 
     # compressing the files as zip
     log("Exporting profile. It might take a minute or two...")

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -40,7 +40,7 @@ def exception_handler(func):
             function = func(*args, **kwargs)
         except Exception as err:
             dateandtime = datetime.now().strftime("[%d/%m/%Y %H:%M:%S]")
-            log_file = os.path.join(HOME, "konsave_log.txt")
+            log_file = os.path.join(HOME, ".konsave_log.txt")
 
             with open(log_file, "a") as file:
                 file.write(dateandtime + "\n")


### PR DESCRIPTION
This PR adds functionality for exporting profiles and adds some protection against overwriting data.

You can pass -n/--export-name to set the name of the exported archive. If this is not set, it is defaulted to the profile name as per the original functionality.

You can pass -d/--export-directory to set the directory of an exported profile. If this is not set, it is now set to the current working directory instead of the users home directory.

You can pass -f/--force alongside -e/--export to force the overwriting of data as per the original functionality. Although this is dangerous, it is important for my workflows to keep the functionality. I use this as part of an ansible provisioner for new workstations, and I rely on a fixed archive name being kept up to date with changes. I could rework my provisioner code to take backups before restoring from konsave so if you wanted to remove the ability to overwrite data completely, it is understandable. I think its important that this function is "hidden" behind the -f option and not default functionality. 

I've changed code that creates a unique export_path to use date time rather than a random string. Helps keep the archives sorted in order, alphanumerically.

I've removed .capitalize() from the log function as it was causing the output logging to present an incorrect name. I have spot checked the other functions that reference the log function and can't see why this would have a knock on effect.