### PR TITLE
Adding a Makefile for devs + linting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,3 @@
 [MASTER]
 disable=broad-except, too-many-locals, too-many-branches
+good-names=i,j,k,v,ex,_,pk,x,y

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,61 @@
+.PHONY: help all setup dev-setup fmt clean distclean maintclean pyfmt black usort tests
+
+all: setup
+
+help:
+		@echo "konsave helper:"
+		@echo ""
+		@echo " - setup:        User-level setup"
+		@echo " - dev-setup:    Development setup"
+		@echo " - fmt:          Format the code with pyfmt"
+		@echo " - clean:        Remove all pyc files"
+		@echo " - distclean:    Remove any eggs/builds"
+		@echo " - maintclean:   Remove virtual env and dist files"
+		@echo ""
+
+setup:
+		@echo "Setting Up (user)"
+		@python3 -m venv .venv
+		@(. .venv/bin/activate && \
+				pip install -r requirements.txt && \
+				python -m pip install --upgrade pip \
+		)
+
+dev-setup: setup
+		@echo "Setting Up (dev)"
+		@@(. .venv/bin/activate && pip install -r requirements_dev.txt)
+
+
+fmt: black pylint
+
+black:
+		@echo " * Running black"
+		@black --safe konsave
+
+
+# TODO: Consider adding this
+# usort:
+# 		@echo " * Running usort"
+# 		@usort format konsave
+
+pylint:
+		@echo " * Running pylint"
+		@pylint konsave
+
+clean:
+		@find . -name "*.pyc" -exec rm -f {} \;
+		@find . -name '__pycache__' -type d | xargs rm -fr
+
+distclean: clean
+		rm -fr *.egg *.egg-info/ .eggs/ dist/ build/
+
+maintclean: distclean
+		rm -fr .venv/
+
+# TODO: Consider adding proper type-checking
+# typecheck:
+#		 mypy -p yacgtc --strict --no-strict-optional --ignore-missing-imports --install-types
+#		 mypy -p tests --no-strict-optional --ignore-missing-imports --install-types
+
+tests:
+		python3 ./test.py

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -91,14 +91,14 @@ def _get_parser() -> argparse.ArgumentParser:
         "--export-directory",
         required=False,
         help="Specify the export directory when exporting a profile",
-        metavar="<directory>"
+        metavar="<directory>",
     )
     parser.add_argument(
         "-n",
         "--export-name",
         required=False,
         help="Specify the export name when exporting a profile",
-        metavar="<archive-name>"
+        metavar="<archive-name>",
     )
     parser.add_argument(
         "-v", "--version", required=False, action="store_true", help="Show version"
@@ -133,8 +133,14 @@ def main():
     elif args.apply:
         apply_profile(args.apply, list_of_profiles, length_of_lop)
     elif args.export_profile:
-        export(args.export_profile, list_of_profiles, length_of_lop,
-               args.export_directory, args.export_name, args.force)
+        export(
+            args.export_profile,
+            list_of_profiles,
+            length_of_lop,
+            args.export_directory,
+            args.export_name,
+            args.force,
+        )
     elif args.import_profile:
         import_profile(args.import_profile)
     elif args.version:

--- a/konsave/funcs.py
+++ b/konsave/funcs.py
@@ -6,7 +6,6 @@ import os
 import shutil
 import traceback
 from datetime import datetime
-from random import shuffle
 from zipfile import is_zipfile, ZipFile
 from konsave.consts import (
     HOME,
@@ -21,7 +20,7 @@ try:
     import yaml
 except ModuleNotFoundError as error:
     raise ModuleNotFoundError(
-        "Please install the module PyYAML using pip: \n" "pip install PyYAML"
+        "Please install the module PyYAML using pip: \n pip install PyYAML"
     ) from error
 
 
@@ -42,7 +41,7 @@ def exception_handler(func):
             dateandtime = datetime.now().strftime("[%d/%m/%Y %H:%M:%S]")
             log_file = os.path.join(HOME, ".cache/konsave_log.txt")
 
-            with open(log_file, "a") as file:
+            with open(log_file, "a", encoding="utf-8") as file:
                 file.write(dateandtime + "\n")
                 traceback.print_exc(file=file)
                 file.write("\n")
@@ -51,8 +50,8 @@ def exception_handler(func):
                 f"Konsave: {err}\nPlease check the log at {log_file} for more details."
             )
             return None
-        else:
-            return function
+
+        return function
 
     return inner_func
 
@@ -122,14 +121,15 @@ def read_konsave_config(config_file) -> dict:
     Args:
         config_file: path to the config file
     """
-    with open(config_file, "r") as text:
+    with open(config_file, "r", encoding="utf-8") as text:
         konsave_config = yaml.load(text.read(), Loader=yaml.SafeLoader)
     parse_keywords(tokens, TOKEN_SYMBOL, konsave_config)
     parse_functions(tokens, TOKEN_SYMBOL, konsave_config)
 
-    # in some cases conf.yaml may contain nothing in "entries"
-    # yaml parses these as NoneType which are not iterable which throws an exception
-    # we can convert all None-Entries into empty lists recursively so they are simply skipped in loops later on
+    # in some cases conf.yaml may contain nothing in "entries". Yaml parses
+    # these as NoneType which are not iterable which throws an exception
+    # we can convert all None-Entries into empty lists recursively so they
+    # are simply skipped in loops later on
     def convert_none_to_empty_list(data):
         if isinstance(data, list):
             data[:] = [convert_none_to_empty_list(i) for i in data]
@@ -285,7 +285,7 @@ def export(profile_name, profile_list, profile_count, archive_dir, archive_name,
     if not force:
         while True:
             paths = [f"{export_path}", f"{export_path}.knsv", f"{export_path}.zip"]
-            if any([os.path.exists(path) for path in paths]):
+            if any(os.path.exists(path) for path in paths):
                 time = "f{:%d-%m-%Y:%H-%M-%S}".format(datetime.now())
                 export_path = f"{export_path}_{time}"
             else:


### PR DESCRIPTION

Hi! 

First of all, thanks for `konsave` - seems like a great project! 

I aim to use it soon but I was curious to see the internals. I also plan to make some new features if I find the time (like for example, list all folders in ~/.config along with if they are backed up in the current profile)

Anyhow, sending this PR which aims to help developers a bit and does formatting changes only. Let me know what you think

---

As per title; doing two things here:

1. Adding a Makefile to ease development/linting/formatting. Example:
    ```
     konsave helper:
     
      - setup:        User-level setup
      - dev-setup:    Development setup
      - fmt:          Format the code with pyfmt
      - clean:        Remove all pyc files
      - distclean:    Remove any eggs/builds
     - maintclean:   Remove virtual env and dist files
    ```

2. Using `make fmt` to clear _most_ of the linting errors (mainly in funcs.py)