### PR TITLE
Add pipx support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@
 ---
 
 ## Installation
-Install from PyPI  
+Install from PyPI using pip  
 `python -m pip install konsave`
+
+Install from PyPI using pipx  
+`pipx install konsave`
 
 ## Usage
 ### Get Help

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYaml>=5.4.1
+setuptools>=75.1.0


### PR DESCRIPTION
Resolves #105

See [this comment](https://github.com/Prayag2/konsave/issues/105#issuecomment-2156401501) for rationale of using pipx and why `setuptools` is needed on Python 3.12 due to the removal of `distutils`.

Besides adding the `setuptools` dependency, also updated the README with how to install using pipx.

Tested locally:
```
$ pipx install --editable .
  installed package Konsave 0.1.dev143+ge379d9e.d20241011, installed using Python 3.12.3
  These apps are now globally available
    - konsave
done! ✨ 🌟 ✨
$ konsave -s test             
Konsave: Profile with this name already exists
Please check the log at /home/test/.cache/konsave_log.txt for more details.
```