### PR TITLE
Updated pkg_resources dependencies to remove warning messages

### DIFF
--- a/konsave/__init__.py
+++ b/konsave/__init__.py
@@ -1,9 +1,9 @@
 """Top-level Konsave package."""
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import distribution, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = distribution(__name__).version
+except PackageNotFoundError:
     # Package is not installed
     pass

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import shutil
-from pkg_resources import resource_filename
+from importlib.resources import files
 from konsave.funcs import (
     list_profiles,
     save_profile,
@@ -91,14 +91,14 @@ def _get_parser() -> argparse.ArgumentParser:
         "--export-directory",
         required=False,
         help="Specify the export directory when exporting a profile",
-        metavar="<directory>",
+        metavar="<directory>"
     )
     parser.add_argument(
         "-n",
         "--export-name",
         required=False,
         help="Specify the export name when exporting a profile",
-        metavar="<archive-name>",
+        metavar="<archive-name>"
     )
     parser.add_argument(
         "-v", "--version", required=False, action="store_true", help="Show version"
@@ -115,10 +115,10 @@ def main():
 
     if not os.path.exists(CONFIG_FILE):
         if os.path.expandvars("$XDG_CURRENT_DESKTOP") == "KDE":
-            default_config_path = resource_filename("konsave", "conf_kde.yaml")
+            default_config_path = str(files("konsave") / "conf_kde.yaml")
             shutil.copy(default_config_path, CONFIG_FILE)
         else:
-            default_config_path = resource_filename("konsave", "conf_other.yaml")
+            default_config_path = str(files("konsave") / "conf_other.yaml")
             shutil.copy(default_config_path, CONFIG_FILE)
 
     parser = _get_parser()
@@ -133,14 +133,8 @@ def main():
     elif args.apply:
         apply_profile(args.apply, list_of_profiles, length_of_lop)
     elif args.export_profile:
-        export(
-            args.export_profile,
-            list_of_profiles,
-            length_of_lop,
-            args.export_directory,
-            args.export_name,
-            args.force,
-        )
+        export(args.export_profile, list_of_profiles, length_of_lop,
+               args.export_directory, args.export_name, args.force)
     elif args.import_profile:
         import_profile(args.import_profile)
     elif args.version:


### PR DESCRIPTION
Updated pkg_resources dependencies to importlib.resources due to depracation and resulting warning messages when using konsave command.

This was the following warning whenever using konsave:

$ konsave
/home/username/.local/share/pipx/venvs/konsave/lib/python3.12/site-packages/konsave/__init__.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import get_distribution, DistributionNotFound
