### PR TITLE
Modernise for Plasma 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@
 ---
 
 ## Installation
-Install from PyPI  
+Install from PyPI using pip  
 `python -m pip install konsave`
+
+Install from PyPI using pipx  
+`pipx install konsave`
 
 ## Usage
 ### Get Help

--- a/konsave/__init__.py
+++ b/konsave/__init__.py
@@ -1,9 +1,9 @@
 """Top-level Konsave package."""
 
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import distribution, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = distribution(__name__).version
+except PackageNotFoundError:
     # Package is not installed
     pass

--- a/konsave/__main__.py
+++ b/konsave/__main__.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import shutil
-from pkg_resources import resource_filename
+from importlib.resources import files
 from konsave.funcs import (
     list_profiles,
     save_profile,
@@ -91,14 +91,14 @@ def _get_parser() -> argparse.ArgumentParser:
         "--export-directory",
         required=False,
         help="Specify the export directory when exporting a profile",
-        metavar="<directory>",
+        metavar="<directory>"
     )
     parser.add_argument(
         "-n",
         "--export-name",
         required=False,
         help="Specify the export name when exporting a profile",
-        metavar="<archive-name>",
+        metavar="<archive-name>"
     )
     parser.add_argument(
         "-v", "--version", required=False, action="store_true", help="Show version"
@@ -115,10 +115,10 @@ def main():
 
     if not os.path.exists(CONFIG_FILE):
         if os.path.expandvars("$XDG_CURRENT_DESKTOP") == "KDE":
-            default_config_path = resource_filename("konsave", "conf_kde.yaml")
+            default_config_path = str(files("konsave") / "conf_kde.yaml")
             shutil.copy(default_config_path, CONFIG_FILE)
         else:
-            default_config_path = resource_filename("konsave", "conf_other.yaml")
+            default_config_path = str(files("konsave") / "conf_other.yaml")
             shutil.copy(default_config_path, CONFIG_FILE)
 
     parser = _get_parser()
@@ -133,14 +133,8 @@ def main():
     elif args.apply:
         apply_profile(args.apply, list_of_profiles, length_of_lop)
     elif args.export_profile:
-        export(
-            args.export_profile,
-            list_of_profiles,
-            length_of_lop,
-            args.export_directory,
-            args.export_name,
-            args.force,
-        )
+        export(args.export_profile, list_of_profiles, length_of_lop,
+               args.export_directory, args.export_name, args.force)
     elif args.import_profile:
         import_profile(args.import_profile)
     elif args.version:

--- a/konsave/conf_kde.yaml
+++ b/konsave/conf_kde.yaml
@@ -65,12 +65,36 @@ save:
             - lightlyrc
             - ksplashrc
             - khotkeysrc
+            # Added for Plasma 6.x compatibility (optional/extra configs)
+            - systemsettingsrc
+            - kded5rc               # renamed from kdedrc (Plasma 6)
+            - kconf_updaterc
+            - kscreenrc            # include if persistent on your system
+            - plasma-systemmonitorrc
+            - spectaclerc
+            - plasmanotifyrc
+            - plasma-localerc
+            - plasma_calendar_holiday_regions
+            - xdg-desktop-portal-kderc
+            - kwinoutputconfig.json
 
     app_layouts:
         location: "$HOME/.local/share/kxmlgui5"
         entries:
             - dolphin
             - konsole
+            # Optional application GUI layout overrides (add if present)
+            - systemsettings
+            - spectacle
+            - plasma-systemmonitor
+
+    # Autostart user .desktop entries (do NOT include distro defaults)
+    autostart:
+        location: "$CONFIG_DIR/autostart"
+        entries:
+            # Enumerated user autostart entries (adjust as needed)
+            - org.kde.yakuake.desktop
+            # Add/remove entries above if your autostart changes.
 
     # Here are a few examples of how you can add more stuff to back up.
     # Uncomment these lines if you want.

--- a/konsave/conf_kde.yaml
+++ b/konsave/conf_kde.yaml
@@ -83,6 +83,7 @@ save:
         entries:
             - dolphin
             - konsole
+            - yakuakerc
             # Optional application GUI layout overrides (add if present)
             - systemsettings
             - spectacle
@@ -122,6 +123,7 @@ export:
             - aurorae
             - icons
             - wallpapers
+            - yakuake
 
     home_folder:
         location: "$HOME/"

--- a/konsave/conf_kde.yaml
+++ b/konsave/conf_kde.yaml
@@ -93,8 +93,6 @@ save:
     autostart:
         location: "$CONFIG_DIR/autostart"
         entries:
-            # Enumerated user autostart entries (adjust as needed)
-            - org.kde.yakuake.desktop
             # Add/remove entries above if your autostart changes.
 
     # Here are a few examples of how you can add more stuff to back up.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 PyYaml>=5.4.1
+setuptools>=75.1.0


### PR DESCRIPTION
This PR
- includes https://github.com/Prayag2/konsave/pull/116 for pipx support
- includes https://github.com/Prayag2/konsave/pull/124 for packaging fixes
- additions to the KDE config to store more Plasma 6 settings

Try this out with
```bash
pipx install git+https://github.com/ftschindler/konsave.git@modernise
```

TODO:
- [x] yakuake settings did not seem to taken into account
- [x] autostart settings likely don't make sense to track in the main config